### PR TITLE
feat: add TrekCore and STAPI integrations for episode metadata

### DIFF
--- a/.ai/plan/feature-episode-metadata-enrichment-1.md
+++ b/.ai/plan/feature-episode-metadata-enrichment-1.md
@@ -70,11 +70,11 @@ This plan extends the existing VBS Service Worker to implement a comprehensive e
 |------|-------------|-----------|------|
 | TASK-011 | Create `src/modules/metadata-sources.ts` factory with Memory Alpha integration using ethical scraping practices | ✅ | 2025-08-13 |
 | TASK-012 | Implement TMDB API integration in metadata-sources.ts with proper authentication and rate limiting | ✅ | 2025-08-13 |
-| TASK-013 | Add TrekCore and other supplementary data sources with fallback hierarchies | |  |
+| TASK-013 | Add TrekCore and other supplementary data sources with fallback hierarchies | ✅ | 2025-08-13 |
 | TASK-014 | Create rate limiting middleware using token bucket algorithm with per-source limits | |  |
 | TASK-015 | Implement retry logic with exponential backoff using existing withErrorHandling utilities | |  |
 | TASK-016 | Add API response caching with smart invalidation based on data freshness requirements | |  |
-| TASK-017 | Create metadata normalization pipeline using composition utilities to standardize data formats | |  |
+| TASK-017 | Create metadata normalization pipeline using composition utilities to standardize data formats | ✅ | 2025-08-13 |
 | TASK-018 | Implement API health monitoring with automatic fallback to cached data when services are unavailable | |  |
 | TASK-019 | Add data enrichment strategies (combine multiple sources, fill gaps, validate consistency) | |  |
 | TASK-020 | Create API usage analytics and quota management to prevent service disruptions | |  |

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -291,6 +291,7 @@ export type MetadataSourceType =
   | 'imdb'
   | 'manual'
   | 'trekcore'
+  | 'stapi'
   | 'startrek-com'
 
 /**
@@ -2807,6 +2808,14 @@ export interface MetadataSourceConfig {
     retryConfig?: RetryConfig
   }
   trekCore?: {
+    enabled: boolean
+    rateLimitConfig: {
+      requestsPerSecond: number
+      burstSize: number
+    }
+    retryConfig?: RetryConfig
+  }
+  stapi?: {
     enabled: boolean
     rateLimitConfig: {
       requestsPerSecond: number

--- a/test/metadata-supplementary-sources.test.ts
+++ b/test/metadata-supplementary-sources.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Test for TrekCore and STAPI supplementary data sources.
+ */
+import type {MetadataSourceInstance} from '../src/modules/types.js'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {createMetadataSources} from '../src/modules/metadata-sources.js'
+
+describe('Supplementary Data Sources', () => {
+  let metadataSources: MetadataSourceInstance
+
+  beforeEach(() => {
+    // Mock fetch globally
+    globalThis.fetch = vi.fn()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('TrekCore Integration', () => {
+    beforeEach(() => {
+      metadataSources = createMetadataSources({
+        trekCore: {
+          enabled: true,
+          rateLimitConfig: {
+            requestsPerSecond: 1,
+            burstSize: 5,
+          },
+        },
+      })
+    })
+
+    it('should handle TrekCore requests', async () => {
+      const mockResponse = new Response(
+        '<!DOCTYPE html><html><body>TrekCore Episode Page</body></html>',
+        {
+          status: 200,
+          headers: {'Content-Type': 'text/html'},
+        },
+      )
+
+      vi.mocked(fetch).mockResolvedValue(mockResponse)
+
+      const result = await metadataSources.enrichEpisode('tos_s1_e01')
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://tos.trekcore.com/episodes/season1/tos1x01.php',
+        expect.any(Object),
+      )
+
+      // TrekCore might return null if it can't parse the page
+      expect(result).toBeDefined()
+    })
+
+    it('should handle TrekCore failures gracefully', async () => {
+      vi.mocked(fetch).mockRejectedValue(new Error('Network error'))
+
+      const result = await metadataSources.enrichEpisode('tos_s1_e01')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('STAPI Integration', () => {
+    beforeEach(() => {
+      metadataSources = createMetadataSources({
+        stapi: {
+          enabled: true,
+          rateLimitConfig: {
+            requestsPerSecond: 2,
+            burstSize: 10,
+          },
+        },
+      })
+    })
+
+    it('should fetch and parse STAPI episode data', async () => {
+      // Mock search response
+      const searchResponse = new Response(
+        JSON.stringify({
+          episodes: [
+            {
+              uid: 'EPMA0000000001',
+              title: 'The Man Trap',
+            },
+          ],
+        }),
+        {status: 200},
+      )
+
+      // Mock episode details response
+      const detailsResponse = new Response(
+        JSON.stringify({
+          episode: {
+            uid: 'EPMA0000000001',
+            title: 'The Man Trap',
+            usAirDate: '1966-09-08',
+            productionSerialNumber: '6149-06',
+            stardate: 1513.1,
+            stardateFrom: 1513.1,
+            stardateTo: 1513.8,
+            yearFrom: 2266,
+            yearTo: 2266,
+          },
+        }),
+        {status: 200},
+      )
+
+      vi.mocked(fetch).mockResolvedValueOnce(searchResponse).mockResolvedValueOnce(detailsResponse)
+
+      const result = await metadataSources.enrichEpisode('tos_s1_e01')
+
+      expect(fetch).toHaveBeenCalledTimes(2)
+      expect(fetch).toHaveBeenNthCalledWith(
+        1,
+        'https://stapi.co/api/v1/rest/episode/search?seasonNumberFrom=1&seasonNumberTo=1&episodeNumberFrom=01&episodeNumberTo=01&pageSize=1',
+        expect.any(Object),
+      )
+      expect(fetch).toHaveBeenNthCalledWith(
+        2,
+        'https://stapi.co/api/v1/rest/episode?uid=EPMA0000000001',
+        expect.any(Object),
+      )
+
+      expect(result).toBeDefined()
+      expect(result?.dataSource).toBe('stapi')
+      expect(result?.confidenceScore).toBe(0.8)
+    })
+
+    it('should handle STAPI API failures gracefully', async () => {
+      vi.mocked(fetch).mockRejectedValue(new Error('API Error'))
+
+      const result = await metadataSources.enrichEpisode('tos_s1_e01')
+
+      expect(result).toBeNull()
+    })
+
+    it('should handle empty STAPI search results', async () => {
+      const searchResponse = new Response(
+        JSON.stringify({
+          episodes: [],
+        }),
+        {status: 200},
+      )
+
+      vi.mocked(fetch).mockResolvedValue(searchResponse)
+
+      const result = await metadataSources.enrichEpisode('tos_s1_e01')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('Multiple Sources Fallback', () => {
+    beforeEach(() => {
+      metadataSources = createMetadataSources({
+        trekCore: {
+          enabled: true,
+          rateLimitConfig: {
+            requestsPerSecond: 1,
+            burstSize: 5,
+          },
+        },
+        stapi: {
+          enabled: true,
+          rateLimitConfig: {
+            requestsPerSecond: 2,
+            burstSize: 10,
+          },
+        },
+      })
+    })
+
+    it('should try multiple sources and return highest confidence result', async () => {
+      // Mock TrekCore to succeed
+      const trekCoreResponse = new Response(
+        '<!DOCTYPE html><html><body>TrekCore Episode Page</body></html>',
+        {
+          status: 200,
+          headers: {'Content-Type': 'text/html'},
+        },
+      )
+
+      // Mock STAPI to succeed with better confidence
+      const stapiSearchResponse = new Response(
+        JSON.stringify({
+          episodes: [
+            {
+              uid: 'EPMA0000000001',
+              title: 'The Man Trap',
+            },
+          ],
+        }),
+        {status: 200},
+      )
+
+      const stapiDetailsResponse = new Response(
+        JSON.stringify({
+          episode: {
+            uid: 'EPMA0000000001',
+            title: 'The Man Trap',
+            usAirDate: '1966-09-08',
+            productionSerialNumber: '6149-06',
+          },
+        }),
+        {status: 200},
+      )
+
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(trekCoreResponse) // TrekCore
+        .mockResolvedValueOnce(stapiSearchResponse) // STAPI search
+        .mockResolvedValueOnce(stapiDetailsResponse) // STAPI details
+
+      const result = await metadataSources.enrichEpisode('tos_s1_e01')
+
+      expect(result).toBeDefined()
+      // STAPI has higher confidence (0.8) than TrekCore (0.75)
+      expect(result?.dataSource).toBe('stapi')
+      expect(result?.confidenceScore).toBe(0.8)
+    })
+  })
+})


### PR DESCRIPTION
- Implement TrekCore and STAPI as supplementary data sources for episode metadata enrichment.
- Add configuration options for enabling and rate limiting these sources.
- Create tests for TrekCore and STAPI integrations, including handling of API responses and errors.
- Introduce metadata normalization and merging strategies to enhance data consistency.

WIP on #147.