### PR TITLE
feat: add movie discovery and metadata fetching for Star Trek

### DIFF
--- a/.ai/plan/feature-automated-data-generation-1.md
+++ b/.ai/plan/feature-automated-data-generation-1.md
@@ -78,6 +78,7 @@ This plan implements an automated system to fetch series, movie, and episode dat
 | TASK-012 | Implement data fetching pipeline using existing `createMetadataSources()` factory with all available sources | ✅ | 2025-10-11 |
 | TASK-013 | Create series discovery logic to fetch complete lists of Star Trek series from TMDB and Memory Alpha | ✅ | 2025-10-11 |
 | TASK-014 | Implement season/episode enumeration for each discovered series with comprehensive metadata collection | ✅ | 2025-10-11 |
+| TASK-015 | Add movie discovery and metadata fetching (theatrical releases, TV movies, special presentations) | ✅ | 2025-10-11 |
 | TASK-015 | Add movie discovery and metadata fetching (theatrical releases, TV movies, special presentations) | | |
 | TASK-016 | Create data normalization pipeline using composition utilities to standardize formats across sources | | |
 | TASK-017 | Implement era classification logic to group content chronologically (Enterprise Era, TOS Era, TNG Era, etc.) | | |


### PR DESCRIPTION
- Implement movie discovery logic to fetch Star Trek movies from TMDB
- Define interfaces for TMDB movie search results, details, and credits
- Create functions to search for movies, fetch details, and enrich movie data
- Integrate movie discovery into the main data generation process

Relates to TASK-015 on #247.